### PR TITLE
ENH: Add scripts for building brain segmentation

### DIFF
--- a/prototype/README.md
+++ b/prototype/README.md
@@ -9,5 +9,7 @@ jupytext --to ipynb my_file.py
 
 Scripts include:
 
-- **nilearn_exploration.py** - Built from an [example from nilearn](https://nilearn.github.io/stable/auto_examples/05_glm_second_level/plot_second_level_association_test.html)
-- **nilearn_prototype.py** - A full workflow that reads ABCD data, processes it, and displays outputs. Processing with nilearn is debugged.  Processing with numpy is supported, but not quite as complete.
+- **[combineSegmentations.py](combineSegmentations.py)** - For each segment of a brain, combines registered individuals to produce an all-segments label map
+- **[nilearn_exploration.py](nilearn_exploration.py)** - Built from an [example from nilearn](https://nilearn.github.io/stable/auto_examples/05_glm_second_level/plot_second_level_association_test.html)
+- **[nilearn_prototype.py](nilearn_prototype.py)** - A full workflow that reads ABCD data, processes it, and displays outputs. Processing with nilearn is debugged.  Processing with numpy is supported, but not quite as complete.
+- **[transformSegmentationsToTemplate.sh](transformSegmentationsToTemplate.sh)** - For each segment of a brain, registers images across individuals using the transforms computed for whole brain images

--- a/prototype/combineSegmentations.py
+++ b/prototype/combineSegmentations.py
@@ -18,20 +18,22 @@ claim.  However, if no region assigns it a value >50% then the voxel is given th
 """
 
 import glob
-from typing import cast
+from typing import Any
 
-import nibabel
 import numpy as np
+import packaging.version
+import slicerio
+import slicerio._version
 from numpy.typing import NDArray
 
 data_dir: str = "/data/lee-data/abcd"
-reference_image: str = data_dir + "/2024-11-15-gor/gortemplate0.nii.gz"
+reference_filename: str = data_dir + "/2024-11-15-gor/gortemplate0.nii.gz"
 output_dir: str = data_dir + "/registration-experiments/2024-01"
 
 deformed_string: str = "Deformed"
 source_types: list[str] = ["mrtrix", "dipy"]
-# Note that we have removed "CC" from `segmentations` because it is redundant with CC_1 through CC_7.
-segmentations: list[str] = [
+# Note that we have removed "CC" from `labels` because it is redundant with CC_1 through CC_7.
+labels: list[str] = [
     "AF_left", "AF_right", "ATR_left", "ATR_right", "CA", "CC_1", "CC_2", "CC_3", "CC_4", "CC_5", "CC_6", "CC_7",
     "CG_left", "CG_right", "CST_left", "CST_right", "FPT_left", "FPT_right", "FX_left", "FX_right", "ICP_left",
     "ICP_right", "IFO_left", "IFO_right", "ILF_left", "ILF_right", "MCP", "MLF_left", "MLF_right", "OR_left",
@@ -42,57 +44,61 @@ segmentations: list[str] = [
     "T_PAR_right", "T_POSTC_left", "T_POSTC_right", "T_PREC_left", "T_PREC_right", "T_PREF_left", "T_PREF_right",
     "T_PREM_left", "T_PREM_right", "UF_left", "UF_right",
 ]
+segment_descriptions: list[dict[str, Any]] = [
+    dict(id=f"Segment_{i}", labelValue=i, name=label) for i, label in enumerate(labels)
+]
 
-source_type_list: list[tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.int32]]] = []
+output_of_source_types: list[tuple[dict[str, Any], dict[str, Any]]] = []
 for source_type in source_types:
-    print(f"Processing {source_type}")
-    mean_image_list: list[tuple[NDArray[np.float64], NDArray[np.float64]]] = []
-    print("  Processing by segmentation")
-    for segmentation in segmentations:
-        print(f"    Processing {segmentation}")
+    print(f"Processing {source_type}", flush=True)
+    mean_arrays_of_segments: list[tuple[NDArray[np.float64], dict[str, Any]]] = []
+    print("  Processing by segmentation", flush=True)
+    for label in labels:
+        print(f"    Processing {label}", flush=True)
         file_glob: str = (
             data_dir
             + "/registration-experiments/2024-01/tractseg_output_"
             + source_type
             + "/*_dwi/bundle_segmentations/"
-            + segmentation
+            + label
             + "_"
             + deformed_string
             + ".nii.gz"
         )
-        file_list: list[str] = glob.glob(file_glob)
-        all_images: NDArray[np.int32] = np.stack(
-            [cast(nibabel.nifti1.Nifti1Image, nibabel.load(file)).get_fdata().astype(np.int32) for file in file_list],
-            axis=0,
+        filenames_of_subjects: list[str] = glob.glob(file_glob)
+        all_input_arrays: NDArray[np.int32] = np.stack(
+            [slicerio.read_segmentation(file)["voxels"].astype(np.int32) for file in filenames_of_subjects], axis=0
         )
-        affine: NDArray[np.float64] = cast(nibabel.nifti1.Nifti1Image, nibabel.load(file_list[0])).affine
-        mean_image: NDArray[np.float64] = np.mean(all_images, axis=0)
-        mean_image_list.append((mean_image, affine))
-        # all_values, all_counts = np.unique(all_images, return_counts=True)
-        # typical_size: float = all_counts[1] / all_images.shape[0]
-        # mean_values, mean_counts = np.unique(mean_image, return_counts=True)
-        # cum_sum: NDArray[np.int32] = np.cumsum(mean_counts[::-1])[::-1]
-        del file_glob, file_list, all_images, mean_image
+        # Note, first two rows of affine are sign flipped relative to nibabel.load(filenames_of_subjects[0]).affine
+        header: dict[str, Any] = {**slicerio.read_segmentation(filenames_of_subjects[0])}
+        del header["voxels"]
+        mean_array: NDArray[np.float64] = np.mean(all_input_arrays, axis=0)
+        mean_arrays_of_segments.append((mean_array, header))
+        del file_glob, filenames_of_subjects, all_input_arrays, header, mean_array
 
-    print("  Combining segmentations")
-    source_type_image: NDArray[np.float64] = np.stack([e[0] for e in mean_image_list], axis=0)
-    source_affine: NDArray[np.float64] = mean_image_list[0][1]
-    source_img: nibabel.nifti1.Nifti1Image = nibabel.Nifti1Image(source_type_image, source_affine, dtype=np.float64)
-
-    which_max_claim: NDArray[np.int32] = np.argmax(source_type_image, axis=0).astype(np.int32)
-    max_claim: NDArray[np.float64] = np.amax(source_type_image, axis=0)
+    print("  Combining segmentations", flush=True)
+    source_img_voxels = np.stack([e[0] for e in mean_arrays_of_segments], axis=0).astype(np.float64)
+    argmax_claim: NDArray[np.int32] = np.argmax(source_img_voxels, axis=0).astype(np.int32)
+    max_claim: NDArray[np.float64] = np.amax(source_img_voxels, axis=0)
     threshold: float = 0.5
-    which_max_claim[max_claim <= threshold] = -1
-    which_img: nibabel.nifti1.Nifti1Image = nibabel.Nifti1Image(which_max_claim, source_affine, dtype=np.int32)
+    argmax_claim[max_claim <= threshold] = -1
 
-    print("  Writing two output files")
-    source_filename: str = output_dir + "/segmentation_data_" + source_type + ".nii.gz"
-    nibabel.save(source_img, source_filename)
-    which_filename: str = output_dir + "/segmentation_labelmap_" + source_type + ".nii.gz"
-    nibabel.save(which_img, which_filename)
+    print("  Writing output files", flush=True)
+    source_img: dict[str, Any] = {**mean_arrays_of_segments[0][1]}
+    source_img["voxels"] = source_img_voxels
+    argmax_img: dict[str, Any] = {**mean_arrays_of_segments[0][1]}
+    argmax_img["voxels"] = argmax_claim
+    argmax_img["segments"] = segment_descriptions
+    if packaging.version.Version(slicerio._version.__version__) > packaging.version.Version("1.1.2"):
+        # This is a 4-dimensional array (label, x, y, z).  Slicerio 1.1.2 chokes in this case, but slicerio
+        # 378205b394a0db277041cfd6f1559542b026fce2 or newer works.
+        source_filename: str = output_dir + "/segmentation_data_" + source_type + ".seg.nrrd"
+        slicerio.write_segmentation(source_filename, source_img)
 
-    source_type_list.append((source_type_image, source_affine, which_max_claim))
-    del mean_image_list, source_type_image, source_affine, source_img, source_filename
-    del which_max_claim, max_claim, threshold, which_img, which_filename
+    argmax_filename: str = output_dir + "/segmentation_labelmap_" + source_type + ".seg.nrrd"
+    slicerio.write_segmentation(argmax_filename, argmax_img)
 
-print("source_type_list created")
+    output_of_source_types.append((source_img, argmax_img))
+    del mean_arrays_of_segments, source_img_voxels, argmax_claim, max_claim, threshold, source_img, argmax_img
+
+print(f"output_of_source_types created.  Also see {output_dir}/.", flush=True)

--- a/prototype/combineSegmentations.py
+++ b/prototype/combineSegmentations.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+"""
+Prior to running this script you will probably have run something like
+
+  transformSegmentationsToTemplate.sh
+
+to create registered label files AF_left_Deformed.nii.gz, AF_right_Deformed.nii.gz, ATR_left_Deformed.nii.gz,
+ATR_right_Deformed.nii.gz, CA_Deformed.nii.gz, CC_Deformed.nii.gz, CC_1_Deformed.nii.gz, CC_2_Deformed.nii.gz, ... for
+each image.
+
+As a first step, this script takes one brain region at a time and computes a consensus image from the individual image
+descriptions of that region.  Instead of a value of 0 for background and 1 for foreground, a consensus image has a value
+in the range [0, 1] at each voxel to represent the fraction of input images that had a value of 1 at that voxel.
+
+As a second step, this script looks at all brain regions together and labels a voxel with the region with the highest
+claim.  However, if no region assigns it a value >50% then the voxel is given the label of -1, for background.
+"""
+
+import glob
+from typing import cast
+
+import nibabel
+import numpy as np
+from numpy.typing import NDArray
+
+data_dir: str = "/data/lee-data/abcd"
+reference_image: str = data_dir + "/2024-11-15-gor/gortemplate0.nii.gz"
+output_dir: str = data_dir + "/registration-experiments/2024-01"
+
+deformed_string: str = "Deformed"
+source_types: list[str] = ["mrtrix", "dipy"]
+# Note that we have removed "CC" from `segmentations` because it is redundant with CC_1 through CC_7.
+segmentations: list[str] = [
+    "AF_left", "AF_right", "ATR_left", "ATR_right", "CA", "CC_1", "CC_2", "CC_3", "CC_4", "CC_5", "CC_6", "CC_7",
+    "CG_left", "CG_right", "CST_left", "CST_right", "FPT_left", "FPT_right", "FX_left", "FX_right", "ICP_left",
+    "ICP_right", "IFO_left", "IFO_right", "ILF_left", "ILF_right", "MCP", "MLF_left", "MLF_right", "OR_left",
+    "OR_right", "POPT_left", "POPT_right", "SCP_left", "SCP_right", "SLF_III_left", "SLF_III_right", "SLF_II_left",
+    "SLF_II_right", "SLF_I_left", "SLF_I_right", "STR_left", "STR_right", "ST_FO_left", "ST_FO_right", "ST_OCC_left",
+    "ST_OCC_right", "ST_PAR_left", "ST_PAR_right", "ST_POSTC_left", "ST_POSTC_right", "ST_PREC_left", "ST_PREC_right",
+    "ST_PREF_left", "ST_PREF_right", "ST_PREM_left", "ST_PREM_right", "T_OCC_left", "T_OCC_right", "T_PAR_left",
+    "T_PAR_right", "T_POSTC_left", "T_POSTC_right", "T_PREC_left", "T_PREC_right", "T_PREF_left", "T_PREF_right",
+    "T_PREM_left", "T_PREM_right", "UF_left", "UF_right",
+]
+
+source_type_list: list[tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.int32]]] = []
+for source_type in source_types:
+    print(f"Processing {source_type}")
+    mean_image_list: list[tuple[NDArray[np.float64], NDArray[np.float64]]] = []
+    print("  Processing by segmentation")
+    for segmentation in segmentations:
+        print(f"    Processing {segmentation}")
+        file_glob: str = (
+            data_dir
+            + "/registration-experiments/2024-01/tractseg_output_"
+            + source_type
+            + "/*_dwi/bundle_segmentations/"
+            + segmentation
+            + "_"
+            + deformed_string
+            + ".nii.gz"
+        )
+        file_list: list[str] = glob.glob(file_glob)
+        all_images: NDArray[np.int32] = np.stack(
+            [cast(nibabel.nifti1.Nifti1Image, nibabel.load(file)).get_fdata().astype(np.int32) for file in file_list],
+            axis=0,
+        )
+        affine: NDArray[np.float64] = cast(nibabel.nifti1.Nifti1Image, nibabel.load(file_list[0])).affine
+        mean_image: NDArray[np.float64] = np.mean(all_images, axis=0)
+        mean_image_list.append((mean_image, affine))
+        # all_values, all_counts = np.unique(all_images, return_counts=True)
+        # typical_size: float = all_counts[1] / all_images.shape[0]
+        # mean_values, mean_counts = np.unique(mean_image, return_counts=True)
+        # cum_sum: NDArray[np.int32] = np.cumsum(mean_counts[::-1])[::-1]
+        del file_glob, file_list, all_images, mean_image
+
+    print("  Combining segmentations")
+    source_type_image: NDArray[np.float64] = np.stack([e[0] for e in mean_image_list], axis=0)
+    source_affine: NDArray[np.float64] = mean_image_list[0][1]
+    source_img: nibabel.nifti1.Nifti1Image = nibabel.Nifti1Image(source_type_image, source_affine, dtype=np.float64)
+
+    which_max_claim: NDArray[np.int32] = np.argmax(source_type_image, axis=0).astype(np.int32)
+    max_claim: NDArray[np.float64] = np.amax(source_type_image, axis=0)
+    threshold: float = 0.5
+    which_max_claim[max_claim <= threshold] = -1
+    which_img: nibabel.nifti1.Nifti1Image = nibabel.Nifti1Image(which_max_claim, source_affine, dtype=np.int32)
+
+    print("  Writing two output files")
+    source_filename: str = output_dir + "/segmentation_data_" + source_type + ".nii.gz"
+    nibabel.save(source_img, source_filename)
+    which_filename: str = output_dir + "/segmentation_labelmap_" + source_type + ".nii.gz"
+    nibabel.save(which_img, which_filename)
+
+    source_type_list.append((source_type_image, source_affine, which_max_claim))
+    del mean_image_list, source_type_image, source_affine, source_img, source_filename
+    del which_max_claim, max_claim, threshold, which_img, which_filename
+
+print("source_type_list created")

--- a/prototype/transformSegmentationsToTemplate.sh
+++ b/prototype/transformSegmentationsToTemplate.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Prior to running this script you will probably have run something like
+#
+#   sh2peaks_batch.sh csd_output_dipy/   hdbet_output/ fod_peaks_dipy/
+#   tractseg.sh       fod_peaks_dipy/    hdbet_output/ tractseg_output_dipy/
+#   sh2peaks_batch.sh csd_output_mrtrix/ hdbet_output/ fod_peaks_mrtrix/
+#   tractseg.sh       fod_peaks_mrtrix/  hdbet_output/ tractseg_output_mrtrix/
+#
+# to create label files AF_left.nii.gz, AF_right.nii.gz, ATR_left.nii.gz, ATR_right.nii.gz, CA.nii.gz, CC.nii.gz,
+# CC_1.nii.gz, CC_2.nii.gz, ... for each image.
+#
+# This script takes these outputs and, using the same transforms that were used for their source whole images, registers
+# each segmentation to the reference image.
+#
+# This script takes no arguments, but the variables that you are most likely to want to change might be these:
+
+PATH="${HOME}/ants-2.5.3/bin:${PATH}"
+data_dir="/data/lee-data/abcd"
+reference_image="${data_dir}/2024-11-15-gor/gortemplate0.nii.gz"
+deformed_string="Deformed"
+
+for source_type in "mrtrix" "dipy"
+do
+    segmentations=$(ls $(\ls -d "${data_dir}"/registration-experiments/2024-01/tractseg_output_"${source_type}"/*_dwi | head -1)/bundle_segmentations | fgrep -v "${deformed_string}")
+    for seg in ${segmentations}
+    do
+        echo "=== Processing ${seg%.nii.gz} ==="
+        for moving_image in $(find "${data_dir}"/registration-experiments/2024-01/tractseg_output_"${source_type}"/*_dwi/bundle_segmentations -name "${seg}")
+        do
+            subject=$(basename "$(dirname "$(dirname "${moving_image}")")")
+            warp=$(\ls "${data_dir}"/2024-11-15-gor/gorinput????-"${subject}"_fa-1Warp.nii.gz | head -1)
+            generic_affine=$(\ls "${data_dir}"/2024-11-15-gor/gorinput????-"${subject}"_fa-0GenericAffine.mat | head -1)
+            output_image="${moving_image%.nii.gz}_${deformed_string}.nii.gz"
+            rm -f "${output_image}"
+            antsApplyTransforms \
+                -d 3 \
+                -i "${moving_image}" \
+                -r "${reference_image}" \
+                -t "${warp}" \
+                -t "${generic_affine}" \
+                -o "${output_image}" \
+                -n GenericLabel
+        done
+    done
+done


### PR DESCRIPTION
Our workflow, `prototype/nilearn_prototype.py` outputs voxel locations where there may be some biologically significant relationship to input variables.  However, we don't immediately now which brain segments these voxels fall within.  This pull request submits two scripts that are steps in building a segmentation from the ABCD image files that were analyzed.