### PR TITLE
Describe brain regions via a probability cloud; orient axes; compute betas

### DIFF
--- a/prototype/combineSegmentations.py
+++ b/prototype/combineSegmentations.py
@@ -91,6 +91,7 @@ for source_type in source_types:
     print("  Writing output files", flush=True)
     source_img: dict[str, Any] = {**mean_arrays_of_segments[0][1]}
     source_img["voxels"] = source_img_voxels
+    source_img["segments"] = segment_descriptions
     argmax_img: dict[str, Any] = {**mean_arrays_of_segments[0][1]}
     argmax_img["voxels"] = argmax_claim
     argmax_img["segments"] = segment_descriptions


### PR DESCRIPTION
Changes include:
1. Create and use `show_maximum_using_partition()` and `show_maximum_using_cloud()`.  For the latter, each brain region is a probability cloud; each voxel is assigned a confidence from 0% to 100% depending on the number of images (subjects) that indicate that registered voxel as part of that brain region.
2. Create and use `best_axis_alignment()` and `orient_data_for_slices()` to find and use the best permutation of the spatial axes (and allowing sign flips as well) to be similar to right-anterior-superior (RAS) coordinates.  This will get us as close as possible to delivering the sagittal, coronal, and axial slices that 3D Slicer delivers.
3. Compute the raw regression coefficient (beta) for each test-variable for each voxel using calls to `nilearn.glm.OLSModel` because `nilearn.mass_univariate.permuted_ols` does not return that to us.
4. Add segment descriptions to cloud segmentation `nrrd` file.
5. Show applicable affine transformation for registered image ijk (Python order) to RAS.
6. Show `fa` template as background when showing a voxel significance plot for `fa` and `md` images.
7. Briefly explain how permutations are used for p-value estimation and provide hyperlinks for more information.
8. Remove `use_numpy()` functionality; it is too far behind `use_nilearn()`.
9. Add Python typing hints.